### PR TITLE
Test acceleration by virtual job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,6 +5,8 @@ shared:
 jobs:
   hub:
     requires: [~commit, ~pr]
+    annotations:
+      screwdriver.cd/virtualJob: true
   a:
     requires: []
   b:
@@ -13,6 +15,8 @@ jobs:
     requires: [~b]
   target:
     requires: [~stage@setup_fail]
+    annotations:
+      screwdriver.cd/virtualJob: true
 stages:
   setup_fail:
     requires: [~hub]


### PR DESCRIPTION
Speed up jobs whose execution is not related to testing by making them virtual jobs.
The jobs in a stage are not made virtual jobs because virtual jobs do not update the status of the stage and the test will not work properly.