### PR TITLE
Test acceleration by virtual job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,6 +5,8 @@ shared:
 jobs:
   hub:
     requires: [~commit, ~pr]
+    annotations:
+      screwdriver.cd/virtualJob: true
   a:
     requires: []
   b:
@@ -15,8 +17,12 @@ jobs:
     requires: [~c]
   target:
     requires: [~stage@simple_success2]
+    annotations:
+      screwdriver.cd/virtualJob: true
   join-target:
     requires: [stage@simple_success1, stage@simple_success2]
+    annotations:
+      screwdriver.cd/virtualJob: true
 stages:
   simple_success1:
     requires: [~hub]


### PR DESCRIPTION
Speed up jobs whose execution is not related to testing by making them virtual jobs.
The jobs in a stage are not made virtual jobs because virtual jobs do not update the status of the stage and the test will not work properly.